### PR TITLE
Update ComposePicker.js

### DIFF
--- a/src/ComposePicker.js
+++ b/src/ComposePicker.js
@@ -42,6 +42,8 @@ export default class ComposePicker extends Component {
   isDateBlocked = ( date ) => {
     if ( this.props.blockBefore ){
       return date.isBefore(moment(), 'day');
+    }else if(this.props.blockAfter){
+      return date.isAfter(moment(), 'day');
     }
     return false;
   }


### PR DESCRIPTION
Added "blockAfter" props to block all future dates so that calendar can be used for reports/analysis of data also in which usually user checks the date ranges from past till today.