### PR TITLE
added onRequestClose

### DIFF
--- a/src/ComposePicker.js
+++ b/src/ComposePicker.js
@@ -123,6 +123,7 @@ export default class ComposePicker extends Component {
         <View><View style={[customStyles.contentInput,styles.contentInput]}>{this.getTitleElement()}</View></View>
         <Modal 
           animationType="slide"
+          onRequestClose={() => this.setModalVisible(false)}
           transparent={false}
           visible={this.state.modalVisible}>
           <View stlye={{flex:1, flexDirection:'column'}}>


### PR DESCRIPTION
onRequestClose is marked as a required prop and used to close the modal on Android when the user presses the back button.