### PR TITLE
Adding custom style for month and date in single mode

### DIFF
--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -36,6 +36,11 @@ const styles = {
     fontSize: normalize(20),
     color: "white",
     fontWeight: "bold"
+  },
+  headerDateSingle: {
+    fontSize: 40,
+    color: "white",
+    fontWeight: "bold"
   }
 };
 
@@ -144,6 +149,10 @@ export default class DateRange extends Component {
       ...styles.headTitleText,
       ...customStyles.headerDateTitle
     };
+    const headerDateSingle = {
+      ...styles.headerDateSingle,
+      ...customStyles.headerDateSingle
+    };
     return (
       <View>
         <View style={headerContainer}>
@@ -155,9 +164,7 @@ export default class DateRange extends Component {
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity onPress={this.selectMonthAndDate}>
-                <Text
-                  style={{ fontSize: 40, color: "white", fontWeight: "bold" }}
-                >
+                <Text style={headerDateSingle}>
                   {this.state.clearSingle}
                 </Text>
               </TouchableOpacity>


### PR DESCRIPTION
I found that there is no way to set a custom style for month and date when the calendar in set in single mode.

My use case was I had to make the header white with the texts in black, so I couldn't do it because the Text element that has the month and date on single mode has the styles hardcoded.

Hope this works, I'll keep an eye if this would need an extra work.

Cheers!