### PR TITLE
Further UI customizations for user

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,24 @@ import DatePicker from 'react-native-date-ranges';
 
 //single picker
 <DatePicker
-	style={ { width: 350, height: 45 } }
+	style={ { width: 350, height: 45 } } // default width will be equal to placeholder text width
 	customStyles = { {
 		placeholderText:{ fontSize:20 }, // placeHolder style
 		headerStyle : {  },			// title container style
 		headerMarkTitle : { }, // title mark style 
 		headerDateTitle: { }, // title Date style
 		contentInput: {}, //content text container style
-		contentText: {}, //after selected text Style
+		contentText: {}, //after selected text style
+                monthPickerText: {}, //focused month picker text style
+                datePickerText: {}, //calendar dates text style
+                dayNameText: {} //day of week title text style (M, T, W, T, F, S, S)
 	} } // optional 
 	centerAlign // optional text will align center or not
 	allowFontScaling = {false} // optional
 	placeholder={'Apr 27, 2018'}
 	selectedBgColor="black"
 	selectedTextColor="blue"
+        calendarBgColor="black"
 />
 
 
@@ -83,6 +87,7 @@ export default class NewPicker extends React.Component{
 | **`customStyles`** | `Object` | optional. customize style e.g.({ placeholderText:{}, headerStyle:{} ... }) |
 | **`style`** | `Object` | Optional. date picker's style |
 | **`onConfirm`** | `Function` | Optional. call function after click button, that would return a date object {startDate:'', endDate:''} e.g( value=>console.log(value))|
+| **`calendarBgColor`** | `String` | Optional. custom the calendar view background color e.g {"black"} |
 | **`selectedBgColor`** | `String` | Optional. custom your selected date background color e.g {"black"} |
 | **`selectedTextColor`** | `String` | Optional. custom your selected date text color e.g {"black"} |
 | **`ButtonStyle`** | `Object` | Optional. custom your save button container style |

--- a/src/ComposePicker.js
+++ b/src/ComposePicker.js
@@ -157,7 +157,7 @@ export default class ComposePicker extends Component {
           this.setModalVisible(true);
         }}
         style={[
-          { width: '100%', height: '100%', justifyContent: 'center' },
+          { height: '100%', justifyContent: 'center' },
           style
         ]}
       >
@@ -173,7 +173,7 @@ export default class ComposePicker extends Component {
             transparent={false}
             visible={this.state.modalVisible}
           >
-            <View stlye={{ flex: 1, flexDirection: 'column' }}>
+            <View style={{ flex: 1, flexDirection: 'column' , backgroundColor: this.props.calendarBgColor}}>
               <View style={{ height: '90%' }}>
                 <DateRange
                   headFormat={this.props.headFormat}
@@ -184,6 +184,7 @@ export default class ComposePicker extends Component {
                   startDate={this.state.startDate}
                   endDate={this.state.endDate}
                   focusedInput={this.state.focus}
+                  calendarBgColor={this.props.calendarBgColor || undefined}
                   selectedBgColor={this.props.selectedBgColor || undefined}
                   selectedTextColor={this.props.selectedTextColor || undefined}
                   mode={this.props.mode || 'single'}

--- a/src/DateRange.js
+++ b/src/DateRange.js
@@ -188,21 +188,22 @@ export default class DateRange extends Component {
           )}
         </View>
         {this.state.selectState === "monthAndDate" && (
-          <View style={styles.calendar}>
+          <View style={[styles.calendar, {backgroundColor: this.props.calendarBgColor}]}>
             <View style={styles.headActionContainer}>
               <TouchableOpacity onPress={this.previousMonth}>
                 <Text
                   style={{
                     paddingHorizontal: 15,
                     fontSize: 18,
-                    fontWeight: "bold"
+                    fontWeight: "bold",
+                    ...customStyles.monthPickerText
                   }}
                 >
                   {"<"}
                 </Text>
               </TouchableOpacity>
               <Text
-                style={{ fontSize: 20, color: "black", fontWeight: "bold" }}
+                style={{ fontSize: 20, color: "black", fontWeight: "bold", ...customStyles.monthPickerText }}
               >
                 {this.state.focusedMonth.format("MMMM YYYY")}
               </Text>
@@ -211,7 +212,8 @@ export default class DateRange extends Component {
                   style={{
                     paddingHorizontal: 15,
                     fontSize: 18,
-                    fontWeight: "bold"
+                    fontWeight: "bold",
+                    ...customStyles.monthPickerText
                   }}
                 >
                   {">"}
@@ -219,6 +221,7 @@ export default class DateRange extends Component {
               </TouchableOpacity>
             </View>
             <Month
+              customStyles={customStyles}
               mode={this.props.mode}
               date={this.props.date}
               startDate={this.props.startDate}
@@ -238,7 +241,7 @@ export default class DateRange extends Component {
           <View
             style={[
               styles.calendar,
-              { height: "75%", justifyContent: "center" }
+              { height: "75%", justifyContent: "center", backgroundColor: this.props.calendarBgColor }
             ]}
           >
             <Picker

--- a/src/Month.js
+++ b/src/Month.js
@@ -19,10 +19,11 @@ const styles = {
     opacity:0.9,
     fontWeight:'bold'
   },
-}
+};
 export default class Month extends Component{
   render(){
     const {
+      customStyles = {},
       mode,
       date,
       startDate,
@@ -36,23 +37,24 @@ export default class Month extends Component{
       selectedBgColor,
       selectedTextColor,
     } = this.props;
-    const dayNames = []; // store week's each day title 
+    const dayNames = []; // store week's each day title
     const weeks = [];
     const startOfMonth = focusedMonth.clone().startOf('month').startOf('isoweek'); // make startOfMonth is immutable
     const endOfMonth = focusedMonth.clone().endOf('month');                        // same logic as below
 
-    // get the interval of week of first day and last day 
+    // get the interval of week of first day and last day
     const weekRange = moment.range(currentDate.clone().startOf('isoweek'), currentDate.clone().endOf('isoweek'));
     weekRange.by('days', (day) => {
       dayNames.push(
-        <Text key={day.date()} style={styles.dayName}>
-          {day.format('dd')[0]} 
+        <Text key={day.date()} style={[styles.dayName, customStyles.dayNameText]}>
+          {day.format('dd')[0]}
         </Text>
       );
     });
     moment.range(startOfMonth, endOfMonth).by('weeks', (week) => {
       weeks.push(
         <Week
+          customStyles={customStyles}
           key={week}
           mode={mode}
           date={date}
@@ -92,4 +94,4 @@ Month.propTypes = {
   onDatesChange: PropTypes.func,
   isDateBlocked: PropTypes.func,
   onDisableClicked: PropTypes.func
-}
+};

--- a/src/Week.js
+++ b/src/Week.js
@@ -1,11 +1,10 @@
 import React, {Component} from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import {Text, TouchableOpacity, View} from 'react-native';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import 'moment-range';
-import { dates } from './dates';
+import {dates} from './dates';
 import normalize from './normalizeText';
-
 
 
 const styles = {
@@ -30,7 +29,7 @@ const styles = {
   daySelected: {
     backgroundColor: "#4597A8",
   },
-  
+
   dayDisabledText: {
     color: 'gray',
     opacity: 0.5,
@@ -47,18 +46,19 @@ const styles = {
     borderTopRightRadius: 20,
     borderBottomRightRadius: 20,
   },
-  borderContainer : { 
-    width:40, 
-    height:40, 
-    alignItems:'center', 
-    justifyContent:'center', 
+  borderContainer : {
+    width:40,
+    height:40,
+    alignItems:'center',
+    justifyContent:'center',
   }
-}
+};
 
 export default class Week extends Component{
-  
+
   render(){
     const {
+      customStyles = {},
       mode,
       date,
       startDate,
@@ -76,16 +76,16 @@ export default class Week extends Component{
     const endOfWeek = startOfWeek.clone().endOf('isoweek');
 
     moment.range(startOfWeek, endOfWeek).by('days', (day) => {
-      
+
       const onPress = () => {
         if (isDateBlocked(day)) {
           onDisableClicked(day);
         } else if (mode === 'range') {
           let isPeriodBlocked = false;
           const start = focusedInput === 'startDate' ? day : startDate;
-          
+
           const end = focusedInput === 'endDate' ? day : endDate;
-          
+
           if (start && end) {
             moment.range(start, end).by('days', (dayPeriod) => {
               if (isDateBlocked(dayPeriod)) isPeriodBlocked = true;
@@ -95,8 +95,7 @@ export default class Week extends Component{
             dates(end, null, 'startDate') :
             dates(start, end, focusedInput));
         } else if (mode === 'single') {
-          const input = day;
-          onDatesChange({ currentDate: input});
+          onDatesChange({ currentDate: day});
         } else {
           onDatesChange({ date: day });
         }
@@ -108,22 +107,22 @@ export default class Week extends Component{
             return day.isSameOrAfter(startDate, 'day') && day.isSameOrBefore(endDate, 'day');
           }
           return (startDate && day.isSame(startDate, 'day')) || (endDate && day.isSame(endDate, 'day'));
-        } 
+        }
         return date && day.isSame(date, 'day');
       };
-      
+
       const isDateSelected = () => {
         if (mode === 'single') {
           return currentDate && day.isSame(currentDate, 'day');
         }
         return date && day.isSame(date, 'day');
-      }
+      };
       const isDateStart = () => {
         return startDate && day.isSame(startDate, 'day');
-      }
+      };
       const isDateEnd = () => {
         return endDate && day.isSame(endDate, 'day');
-      }
+      };
 
       const isBlocked = isDateBlocked(day);
       const isRangeSelected = isDateRangeSelected();
@@ -143,18 +142,19 @@ export default class Week extends Component{
 
       const styleText = [
         styles.dayText,
+        customStyles.datePickerText,
         isBlocked && styles.dayDisabledText,
         isRangeSelected && daySelectedText,
         isSelected && daySelectedText,
       ];
-      const borderContainer = (mode === 'single') && isSelected 
+      const borderContainer = (mode === 'single') && isSelected
         ? [styles.borderContainer,
-          { borderRadius:20, 
-            backgroundColor: 
-              selectedBgColor 
-              ? selectedBgColor 
+          { borderRadius:20,
+            backgroundColor:
+              selectedBgColor
+              ? selectedBgColor
               : styles.daySelected.backgroundColor
-          }] 
+          }]
         : styles.borderContainer;
       days.push(
         <TouchableOpacity
@@ -163,7 +163,7 @@ export default class Week extends Component{
           onPress={onPress}
           disabled={isBlocked && !onDisableClicked}
         >
-          <View style={borderContainer}> 
+          <View style={borderContainer}>
             <Text style={styleText}>{day.date()}</Text>
           </View>
         </TouchableOpacity>
@@ -185,4 +185,4 @@ Week.propTypes = {
   onDatesChange: PropTypes.func,
   isDateBlocked: PropTypes.func,
   onDisableClicked: PropTypes.func
-}
+};


### PR DESCRIPTION
Added prop 'calendarBgColor' to change calendar background color.

Added 3 customStyles:
1. monthPickerText: To change text style for focused month
2. datePickerText: To change text style for calendar date
3. dayNameText: To change text style for name of day of week (M, T, W, T, F, S, S)

Changed input placeholder width from 100% to fit width of text inside. Makes handling width more manageable for user. Instead of specifying a particular width to override 100%, user can just optionally add paddingHorizontal to make the width dynamic according to inner text.

Updated README to reflect additional props and styles in code

Closes #32 